### PR TITLE
Fix for GNOME Shell 3.16

### DIFF
--- a/workspace-isolated-dash/extension.js
+++ b/workspace-isolated-dash/extension.js
@@ -41,7 +41,12 @@ const WorkspaceIsolator = new Lang.Class({
 				if (WorkspaceIsolator.isCurrentApp(this.app)) {
 					this._workspace_isolated_dash_nyuki__onStateChanged();
 				} else {
-					this.actor.remove_style_class_name('running');
+					if (this._dot) {
+						// GNOME Shell 3.16+
+						this._dot.hide();
+					} else {
+						this.actor.remove_style_class_name('running');
+					}
 				}
 			};
 		} else if (AppIcon.prototype._updateRunningStyle) {
@@ -50,7 +55,12 @@ const WorkspaceIsolator = new Lang.Class({
 				if (WorkspaceIsolator.isCurrentApp(this.app)) {
 					this._workspace_isolated_dash_nyuki__updateRunningStyle();
 				} else {
-					this.actor.remove_style_class_name('running');
+					if (this._dot) {
+						// GNOME Shell 3.16+
+						this._dot.hide();
+					} else {
+						this.actor.remove_style_class_name('running');
+					}
 				}
 			};
 		}

--- a/workspace-isolated-dash/metadata.json
+++ b/workspace-isolated-dash/metadata.json
@@ -2,7 +2,7 @@
 	"uuid": "workspace-isolated-dash@n-yuki",
 	"name": "Workspace Isolated Dash",
 	"description": "Isolate workspaces, making the Overview look and behave as if the active workspace is the only workspace (except the workspace switcher).\nThis means it will only show an app icon in the dash if the application has a window on the active workspace (unless they are favourited), activating an application will try open a new window if there are no existing windows on the active workspace, and the overview will only display app icons as 'running' if the application has a window on the active workspace.",
-	"shell-version": [ "3.12", "3.14" ],
+	"shell-version": [ "3.12", "3.14", "3.16" ],
 	"settings-schema": "org.gnome.shell.extensions.n-yuki.workspace-isolated-dash",
 	"url": "https://github.com/N-Yuki/gnome-shell-extension-workspace-isolated-dash"
 }


### PR DESCRIPTION
On GNOME 3.16, all favorited apps in the dash are shown as running.
