### PR TITLE
Ported to gnome-shell 3.30

### DIFF
--- a/workspace-isolated-dash/extension.js
+++ b/workspace-isolated-dash/extension.js
@@ -44,7 +44,7 @@ const WorkspaceIsolator = new Lang.Class({
 		// - window moved to another workspace
 		// - window created
 		// - window closed
-		this._onRestackedId = global.screen.connect('restacked', WorkspaceIsolator.refresh);
+		this._onRestackedId = global.display.connect('restacked', WorkspaceIsolator.refresh);
 	},
 
 	destroy: function() {
@@ -65,7 +65,7 @@ const WorkspaceIsolator = new Lang.Class({
 		}
 		// Disconnect the restacked signal
 		if (this._onRestackedId) {
-			global.screen.disconnect(this._onRestackedId);
+			global.display.disconnect(this._onRestackedId);
 			this._onRestackedId = 0;
 		}
 		// Disconnect the switch-workspace signal
@@ -77,7 +77,7 @@ const WorkspaceIsolator = new Lang.Class({
 });
 // Check if an application is on the active workspace
 WorkspaceIsolator.isActiveApp = function(app) {
-	return app.is_on_workspace(global.screen.get_active_workspace());
+	return app.is_on_workspace(global.workspaceManager.get_active_workspace());
 };
 // Refresh dash
 WorkspaceIsolator.refresh = function() {

--- a/workspace-isolated-dash/metadata.json
+++ b/workspace-isolated-dash/metadata.json
@@ -2,7 +2,7 @@
 	"uuid": "workspace-isolated-dash@n-yuki",
 	"name": "Workspace Isolated Dash",
 	"description": "Isolate workspaces, making the Overview look and behave as if the active workspace is the only workspace (except the workspace switcher).\nThis means it will only show an app icon in the dash if the application has a window on the active workspace (unless they are favourited), activating an application will try open a new window if there are no existing windows on the active workspace, and the overview will only display app icons as 'running' if the application has a window on the active workspace.",
-	"shell-version": [ "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.28"],
+	"shell-version": [ "3.30"],
 	"settings-schema": "org.gnome.shell.extensions.n-yuki.workspace-isolated-dash",
 	"url": "https://github.com/N-Yuki/gnome-shell-extension-workspace-isolated-dash"
 }


### PR DESCRIPTION
- global.screen => global.display
- .get_current_workspace() is now in global.workspaceManager

This version drops compatibility with any older version of gnome-shell. I prefer this variation as it keeps the code simpler and this extension is rather stable feature wise, so users of older gnome-shell versions can just use older versions of the extension.

OTOH if you prefer a version with a compatibility layer, I have [a version prepared in my compat-branch](https://github.com/adamschmalhofer/gnome-shell-extension-workspace-isolated-dash/tree/compat) that you can merge instead.

If you have any changes that you which for me to make, don't hesitate to tell me.