### PR TITLE
Port to gnome-shell 3.36

### DIFF
--- a/workspace-isolated-dash/extension.js
+++ b/workspace-isolated-dash/extension.js
@@ -92,7 +92,7 @@ WorkspaceIsolator.refresh = function() {
 		app.notify('state');
 	});
 	// Update applications shown in the dash
-	Main.overview._dash._queueRedisplay();
+	Main.overview._overview._controls.dash._queueRedisplay();
 };
 
 let _wsIsolator;


### PR DESCRIPTION
Dash was moved to overview controls

Fixes: N-Yuki/gnome-shell-extension-workspace-isolated-dash#21